### PR TITLE
Make .git suffix in remote URL optional

### DIFF
--- a/plugin/github.vim
+++ b/plugin/github.vim
@@ -134,7 +134,7 @@ function! s:ProjectUrl()
   if !exists('b:project_url')
     let remote_url = s:Remote()
     let user = matchstr(remote_url,'.*github\.com[:/]\zs[^/]\+\ze\/.*')
-    let project = matchstr(remote_url,'.*github\.com[:/][^/]\+\/\zs[^.]\+\ze\.git')
+    let project = matchstr(remote_url,'.*github\.com[:/][^/]\+\/\zs[^.]\+\ze\(\.git\)\=')
     let b:project_url = 'http://github.com/'.user.'/'.project
   endif
   return b:project_url


### PR DESCRIPTION
This fixes a bug on my machine where GitHubOpen would not work on repos which
had remote urls like

```console
$ git remote -v
origin  https://github.com/jez/dotfiles (fetch)
origin  https://github.com/jez/dotfiles (push)
```

That is, repos which did not have the trailing `.git` suffix in the remote URLs.

This PR alters the appropriate regex to make it optional.