### PR TITLE
The Github url is incorrect; results in redirect

### DIFF
--- a/plugin/github.vim
+++ b/plugin/github.vim
@@ -135,7 +135,7 @@ function! s:ProjectUrl()
     let remote_url = s:Remote()
     let user = matchstr(remote_url,'.*github\.com[:/]\zs[^/]\+\ze\/.*')
     let project = matchstr(remote_url,'.*github\.com[:/][^/]\+\/\zs[^.]\+\ze\(\.git\)\=')
-    let b:project_url = 'http://github.com/'.user.'/'.project
+    let b:project_url = 'https://github.com/'.user.'/'.project
   endif
   return b:project_url
 endfunction
@@ -143,7 +143,7 @@ endfunction
 " the github repository url
 function! s:ReposUrl()
   if !exists('b:repos_url')
-    let b:repos_url = s:ProjectUrl().'/tree/'.s:CurrentBranch()
+    let b:repos_url = s:ProjectUrl().'/blob/'.s:CurrentBranch()
   endif
   return b:repos_url
 endfunction


### PR DESCRIPTION
The url yanked: `http://github.com/username/project-repo/tree/master/path/to/file.txt#L3-3`
The url should be: `https://github.com/username/project-repo/blob/master/path/to/file.txt#L3-3`

The two issues are with the generated url and the correct one are the protocol should be https, and the 'tree' path part should be 'blob'.

This results in github redirecting to the correct url, losing the anchor to the highlighted lines.