### PR TITLE
Fix github highlight lines

### DIFF
--- a/plugin/github.vim
+++ b/plugin/github.vim
@@ -11,7 +11,7 @@ function! s:Hash(n1,n2)
   if a:n1 == a:n2
     return '#L' . a:n1
   else
-    return '#L' . a:n1 . '-' . a:n2
+    return '#L' . a:n1 . ',L' . a:n2
   endif
 endfunction
 


### PR DESCRIPTION
It seems Github doesn't support any more highlight lines with `#L1,2` so hence the fix.