### PR TITLE
Mark plugin as loaded to avoid redefined function errors

### DIFF
--- a/plugin/github.vim
+++ b/plugin/github.vim
@@ -217,3 +217,5 @@ function! s:YankUrl(url)
     silent call system('xsel --clipboard --input', a:url) 
   endif
 endfunction
+
+let loaded_github = 1


### PR DESCRIPTION
Without marking the plugin as loaded all the functions are redefined which displays errors if the file is sourced a second time. This marks the plugin as loaded to avoid redefining functions.