### PR TITLE
Update regexes for GH Enterprise compatibility

### DIFF
--- a/plugin/github.vim
+++ b/plugin/github.vim
@@ -117,7 +117,7 @@ endfunction
 function! s:Remote()
   if !exists('b:remote')
     let remotes = split(s:CdExec(expand("%:p:h"),'git remote -v'),"\n")
-    let github_remotes = filter(remotes, 'v:val =~ "github\.com"')
+    let github_remotes = filter(remotes, 'v:val =~ "github\."')
     if empty(github_remotes)
       return
     endif
@@ -142,9 +142,10 @@ endfunction
 function! s:ProjectUrl()
   if !exists('b:project_url')
     let remote_url = s:Remote()
-    let user = matchstr(remote_url,'.*github\.com[:/]\zs[^/]\+\ze\/.*')
-    let project = matchstr(remote_url,'.*github\.com[:/][^/]\+\/\zs[^.]\+\ze\(\.git\)\=')
-    let b:project_url = 'https://github.com/'.user.'/'.project
+    let basename = matchstr(remote_url, 'github.[^:/]\+')
+    let user = matchstr(remote_url, 'github.[^:/]\+[:\/]\zs[^/]*')
+    let project = matchstr(remote_url, 'github.[^:/]\+[:\/][^/]\+\/\zs[^.]\+\ze\(\.git\)\=')
+    let b:project_url = 'https://'.basename.'/'.user.'/'.project
   endif
   return b:project_url
 endfunction


### PR DESCRIPTION
My organization uses Github Enterprise, and our repos are accessed at
github.company.tld/organization/project. This commit updates the
ProjectUrl() and Remote() functions to be more flexible around
subdomains so the plugin works for such cases, in addition to regular
github. Thanks for the awesome plugin!